### PR TITLE
Added support for one $and conjunction case and one negation case (relations)

### DIFF
--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -118,10 +118,36 @@ class MongoToKnex {
             debugExtended(`(buildRelationQuery) ${JSON.stringify(relations)}`);
         }
 
-        const groupedRelations = _.groupBy(relations, 'table');
+        const groupedRelations = {};
+
+        _.each(relations, (relation) => {
+            if (!groupedRelations[relation.table]) {
+                groupedRelations[relation.table] = [];
+            }
+
+            if (groupedRelations[relation.table].length) {
+                const columnExists = _.find(groupedRelations[relation.table], (statement) => {
+                    // CASE: we should not use the same sub query if the column name is the same (two sub queries)
+                    if (statement.column === relation.column) {
+                        return true;
+                    }
+                });
+
+                if (columnExists) {
+                    if (!groupedRelations[relation.table + '_']) {
+                        groupedRelations[relation.table + '_'] = [];
+                    }
+
+                    groupedRelations[relation.table + '_'].push(relation);
+                    return;
+                }
+            }
+
+            groupedRelations[relation.table].push(relation);
+        });
 
         if (debugExtended.enabled) {
-            debugExtended(`(buildRelationQuery) grouped: ${JSON.stringify(relations)}`);
+            debugExtended(`(buildRelationQuery) grouped: ${JSON.stringify(groupedRelations)}`);
         }
 
         // CASE: {tags: [where clause, where clause], authors: [where clause, where clause]}

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -160,8 +160,8 @@ class MongoToKnex {
                 if (isCompOp(reference.operator)) {
                     const comp = reference.operator === '$ne' || reference.operator === '$nin' ? 'NOT IN' : 'IN';
 
-                    // CASE: post.id IN (SELECT ...)
-                    qb.where(`${this.tableName}.id`, comp, function () {
+                    // CASE: WHERE post.id IN (SELECT ...)
+                    qb[reference.whereType](`${this.tableName}.id`, comp, function () {
                         const innerQB = this
                             .select(`${reference.config.join_table}.${reference.config.join_from}`)
                             .from(`${reference.config.join_table}`)
@@ -169,8 +169,7 @@ class MongoToKnex {
 
                         _.each(statements, (value, key) => {
                             debug(`(buildRelationQuery) build relation where statements for ${key}`);
-
-                            innerQB.where(`${value.join_table || value.table}.${value.column}`, 'IN', !_.isArray(value.value) ? [value.value] : value.value);
+                            innerQB[value.whereType](`${value.join_table || value.table}.${value.column}`, 'IN', !_.isArray(value.value) ? [value.value] : value.value);
                         });
 
                         return innerQB;
@@ -196,11 +195,12 @@ class MongoToKnex {
         const whereType = this.processWhereType(mode, op, value);
         const processedStatement = this.processStatement(statement, op, value);
 
-        debug(`(buildComparison) isRelation: ${processedStatement.isRelation}, group: ${group}`);
+        debug(`(buildComparison) mode: ${mode}, op: ${op}, isRelation: ${processedStatement.isRelation}, group: ${group}`);
 
         if (processedStatement.isRelation) {
             // CASE: if the statement is not part of a group, execute the query instantly
             if (!group) {
+                processedStatement.whereType = whereType;
                 this.buildRelationQuery(qb, [processedStatement]);
                 return;
             }
@@ -210,6 +210,7 @@ class MongoToKnex {
                 qb.relations = [];
             }
 
+            processedStatement.whereType = whereType;
             qb.relations.push(processedStatement);
             return;
         }

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -116,6 +116,12 @@ class MongoToKnex {
 
         const groupedRelations = {};
 
+        /**
+         * We group the relations by a unique key.
+         * Each grouping will create a sub query.
+         *
+         * @TODO: choose a different key name (!)
+         */
         _.each(relations, (relation) => {
             if (!groupedRelations[relation.table]) {
                 groupedRelations[relation.table] = [];
@@ -123,7 +129,11 @@ class MongoToKnex {
 
             if (groupedRelations[relation.table].length) {
                 const columnExists = _.find(groupedRelations[relation.table], (statement) => {
-                    // CASE: we should not use the same sub query if the column name is the same (two sub queries)
+                    /**
+                     * CASE:
+                     * - we should not use the same sub query if the column name is the same (two sub queries)
+                     * - e.g. $and conjunction requires us to use 2 sub queries, because we have to look at each individual tag
+                     */
                     if (statement.column === relation.column) {
                         return true;
                     }
@@ -147,7 +157,7 @@ class MongoToKnex {
             debugExtended(`(buildRelationQuery) grouped: ${JSON.stringify(groupedRelations)}`);
         }
 
-        // CASE: {tags: [where clause, where clause], authors: [where clause, where clause]}
+        // CASE: {tags: [where clause, where clause], tags_123: [where clause], authors: [where clause, where clause]}
         _.each(Object.keys(groupedRelations), (key) => {
             debug(`(buildRelationQuery) build relation for ${key}`);
 
@@ -160,7 +170,7 @@ class MongoToKnex {
                 if (isCompOp(reference.operator)) {
                     const comp = reference.operator === '$ne' || reference.operator === '$nin' ? 'NOT IN' : 'IN';
 
-                    // CASE: WHERE post.id IN (SELECT ...)
+                    // CASE: WHERE resource.id (IN | NOT IN) (SELECT ...)
                     qb[reference.whereType](`${this.tableName}.id`, comp, function () {
                         const innerQB = this
                             .select(`${reference.config.join_table}.${reference.config.join_from}`)

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -161,10 +161,10 @@ class MongoToKnex {
 
             if (reference.config.type === 'manyToMany') {
                 if (isCompOp(reference.operator)) {
-                    const comp = compOps[reference.operator] || '=';
+                    const comp = reference.operator === '$ne' || reference.operator === '$nin' ? 'NOT IN' : 'IN';
 
                     // CASE: post.id IN (SELECT ...)
-                    qb.where(`${this.tableName}.id`, 'IN', function () {
+                    qb.where(`${this.tableName}.id`, comp, function () {
                         const innerQB = this
                             .select(`${reference.config.join_table}.${reference.config.join_from}`)
                             .from(`${reference.config.join_table}`)
@@ -173,7 +173,7 @@ class MongoToKnex {
                         _.each(statements, (value, key) => {
                             debug(`(buildRelationQuery) build relation where statements for ${key}`);
 
-                            innerQB.where(`${value.join_table || value.table}.${value.column}`, comp, value.value);
+                            innerQB.where(`${value.join_table || value.table}.${value.column}`, 'IN', !_.isArray(value.value) ? [value.value] : value.value);
                         });
 
                         return innerQB;

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -105,11 +105,7 @@ class MongoToKnex {
     }
 
     /**
-     * @TODO: This implementation serves currently the following use cases:
-     *
-     * - OR conjunctions for many-to-many relations
-     * - filter by multiple relation columns
-     * - filter by columns on the join table
+     * Build queries for relations.
      */
     buildRelationQuery(qb, relations) {
         debug(`(buildRelationQuery)`);
@@ -134,11 +130,12 @@ class MongoToKnex {
                 });
 
                 if (columnExists) {
-                    if (!groupedRelations[relation.table + '_']) {
-                        groupedRelations[relation.table + '_'] = [];
+                    const newKey = `${relation.table}_${Math.floor(Math.random() * 100)}`;
+                    if (!groupedRelations[newKey]) {
+                        groupedRelations[newKey] = [];
                     }
 
-                    groupedRelations[relation.table + '_'].push(relation);
+                    groupedRelations[newKey].push(relation);
                     return;
                 }
             }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint . --ext .js --cache",
     "posttest": "yarn lint",
-    "test": "yarn test-unit && yarn test-integration",
+    "test": "yarn test-unit && yarn test-integration --timeout 10000",
     "test-unit": "mocha ./test/unit/*.test.js --exit",
     "test-integration": "mocha ./test/integration/*.test.js --exit",
     "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn publish && git push --follow-tags; fi"

--- a/test/integration/relations.test.js
+++ b/test/integration/relations.test.js
@@ -103,6 +103,24 @@ describe('Relations', function () {
             });
         });
 
+        describe('NEGATION', function () {
+            // should return posts without tags
+            // if a post has more than 1 tag, if one tag is animal, do not return
+            it('tags.slug is NOT "animal"', function () {
+                const mongoJSON = {
+                    'tags.slug': {$ne: 'animal'}
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(4);
+                    });
+            });
+        });
+
         describe('Multiple where clauses for relations', function () {
             it('tags.slug equals "animal" and posts_tags.sort_order is 0 and featured is true', function () {
                 // where primary tag is "animal"

--- a/test/integration/relations.test.js
+++ b/test/integration/relations.test.js
@@ -226,6 +226,20 @@ describe('Relations', function () {
                         result.should.be.an.Array().with.lengthOf(2);
                     });
             });
+
+            it('tags.slug is animal and tags.slug not in []', function () {
+                const mongoJSON = {
+                    $and: [{'tags.slug': 'animal'},{'tags.slug': {$nin: ['classic']}}]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                    });
+            });
         });
 
         describe('OR', function () {

--- a/test/integration/relations.test.js
+++ b/test/integration/relations.test.js
@@ -187,6 +187,29 @@ describe('Relations', function () {
             });
         });
 
+        describe('AND', function () {
+            it('tags.slug is animal and classic', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tags.slug': 'animal'
+                        },
+                        {
+                            'tags.slug': 'classic'
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                    });
+            });
+        });
+
         describe('OR', function () {
             it('tags.slug IN (animal)', function () {
                 const mongoJSON = {

--- a/test/integration/relations.test.js
+++ b/test/integration/relations.test.js
@@ -116,7 +116,7 @@ describe('Relations', function () {
                 return query
                     .select()
                     .then((result) => {
-                        result.should.be.an.Array().with.lengthOf(4);
+                        result.should.be.an.Array().with.lengthOf(5);
                     });
             });
         });
@@ -240,6 +240,58 @@ describe('Relations', function () {
                         result.should.be.an.Array().with.lengthOf(1);
                     });
             });
+
+            it('(tags.slug is animal and sort_order is 0) and tags.visibility=public', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            $and: [
+                                {
+                                    'tags.slug': 'animal'
+                                },
+                                {
+                                    'posts_tags.sort_order': 0
+                                }
+                            ]
+                        },
+                        {
+                            'tags.visibility': 'public'
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                    });
+            });
+
+            it('tags.slug is animal and sort_order is 0 and tags.visibility=public', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tags.slug': 'animal'
+                        },
+                        {
+                            'posts_tags.sort_order': 0
+                        },
+                        {
+                            'tags.visibility': 'public'
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                    });
+            });
         });
 
         describe('OR', function () {
@@ -256,6 +308,58 @@ describe('Relations', function () {
                     .select()
                     .then((result) => {
                         result.should.be.an.Array().with.lengthOf(3);
+                    });
+            });
+
+            it('(tags.slug = animal and sort_order = 0) OR visibility:internal', function () {
+                const mongoJSON = {
+                    $or: [
+                        {
+                            $and: [
+                                {
+                                    'tags.slug': 'animal'
+                                },
+                                {
+                                    'posts_tags.sort_order': 0
+                                }
+                            ]
+                        },
+                        {
+                            'tags.visibility': 'internal'
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                    });
+            });
+
+            it('tags.slug = animal OR sort_order = 0 OR visibility:internal', function () {
+                const mongoJSON = {
+                    $or: [
+                        {
+                            'tags.slug': 'animal'
+                        },
+                        {
+                            'posts_tags.sort_order': 0
+                        },
+                        {
+                            'tags.visibility': 'internal'
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(7);
                     });
             });
 

--- a/test/integration/suite1/fixtures/base.json
+++ b/test/integration/suite1/fixtures/base.json
@@ -72,6 +72,14 @@
             "image": null,
             "status": "published",
             "author_id": 1
+        },
+        {
+            "id": 8,
+            "title": "has internal tag",
+            "featured": true,
+            "image": null,
+            "status": "published",
+            "author_id": 2
         }
     ],
     "tags": [

--- a/test/integration/suite1/fixtures/relations1.json
+++ b/test/integration/suite1/fixtures/relations1.json
@@ -7,6 +7,7 @@
         {"post_id": 4, "tag_id": 2, "sort_order": 1},
         {"post_id": 5, "tag_id": 1, "sort_order": 0},
         {"post_id": 6, "tag_id": 1, "sort_order": 0},
-        {"post_id": 6, "tag_id": 2, "sort_order": 1}
+        {"post_id": 6, "tag_id": 2, "sort_order": 1},
+        {"post_id": 8, "tag_id": 4, "sort_order": 1}
     ]
 }

--- a/test/integration/where.test.js
+++ b/test/integration/where.test.js
@@ -13,7 +13,7 @@ describe('Where', function () {
 
         return query
             .then((results) => {
-                results.length.should.eql(5);
+                results.length.should.eql(6);
             });
     });
 });


### PR DESCRIPTION
refs #5 

- `$and: [tags.slug:en, tags.slug:de]`
- `$and: [{'tags.slug': 'animal'},{'tags.slug': {$nin: ['classic']}}]`

refs #7

- `tags.slug:-animal`

And some more 👻

- https://github.com/NexesJS/mongo-knex/pull/16/commits/12aada32ecae2d07dc0353bba56ccc384be14a09
- https://github.com/NexesJS/mongo-knex/pull/16/commits/cf5334a96963d5adc81e0a14a4afadbbdbfa5a93