### PR TITLE
Support for negation and conjunctions on join table in M:M relation

### DIFF
--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -96,7 +96,7 @@ class MongoToKnex {
             };
         }
 
-        // CASE: fallback, `status=drat` -> `posts.status`=draft
+        // CASE: fallback, `status=draft` -> `posts.status`=draft
         return {
             column: `${this.tableName}.${column}`,
             value: value,

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -96,7 +96,7 @@ class MongoToKnex {
             };
         }
 
-        // CASE: fallback, `status=draft` -> `posts.status`=draft
+        // CASE: fallback, `status=drat` -> `posts.status`=draft
         return {
             column: `${this.tableName}.${column}`,
             value: value,
@@ -105,53 +105,88 @@ class MongoToKnex {
     }
 
     /**
+     * We group the relations by a unique key.
+     * Each grouping will create a sub query.
+     *
+     * @TODO: choose a different key name (!)
+     *
+     * Returns a group structure of following format:
+     *  {
+     *      "groupKey": {
+     *          innerWhereStatements: [],
+     *          joinFilterStatements: []
+     *      }
+     *  }
+     */
+    groupRelationStatements(statements, mode) {
+        const group = {};
+
+        // groups depend on the mode of grouping, if its and $and we need to treat a filter on
+        // joining table differently than we would with $or
+        // e.g. for $or we can create a subquery or group that filter,
+        //      for $and we have to include joining table filter in every group
+        const innerWhereStatements = (mode === '$and')
+            ? statements.filter(r => !(r.join_table))
+            : statements;
+
+        _.each(innerWhereStatements, (statement) => {
+            /**
+             * CASE:
+             * - we should not use the same sub query if the column name is the same (two sub queries)
+             * - e.g. $and conjunction requires us to use 2 sub queries, because we have to look at each individual tag
+             *
+             * - we should also not use grouping of negated values for the same reasons as above
+             */
+            let createSubGroup = isNegationOp(statement.operator);
+
+            if (!createSubGroup && group[statement.table]) {
+                createSubGroup = _.find(group[statement.table].innerWhereStatements, (innerStatement) => {
+                    if (innerStatement.column === statement.column) {
+                        return true;
+                    }
+                });
+            }
+
+            let groupKey = statement.table;
+
+            if (createSubGroup) {
+                // TODO: while this is 'good enough' approach this needs to be approached with something
+                // more stable than random from 1..100
+                groupKey = `${statement.table}_${Math.floor(Math.random() * 100)}`;
+            }
+
+            if (!group[groupKey]) {
+                group[groupKey] = {};
+                group[groupKey].innerWhereStatements = [];
+            }
+
+            group[groupKey].innerWhereStatements.push(statement);
+        });
+
+        // NOTE: filters applied on join level have to be included when they are
+        // a part of $and  group
+        if (mode === '$and') {
+            const joinFilterStatements = statements.filter(r => (r.join_table));
+
+            _.each(Object.keys(group), (key) => {
+                group[key].joinFilterStatements = joinFilterStatements;
+            });
+        }
+
+        return group;
+    }
+
+    /**
      * Build queries for relations.
      */
-    buildRelationQuery(qb, relations) {
+    buildRelationQuery(qb, relations, mode) {
         debug(`(buildRelationQuery)`);
 
         if (debugExtended.enabled) {
             debugExtended(`(buildRelationQuery) ${JSON.stringify(relations)}`);
         }
 
-        const groupedRelations = {};
-
-        /**
-         * We group the relations by a unique key.
-         * Each grouping will create a sub query.
-         *
-         * @TODO: choose a different key name (!)
-         */
-        _.each(relations, (relation) => {
-            if (!groupedRelations[relation.table]) {
-                groupedRelations[relation.table] = [];
-            }
-
-            if (groupedRelations[relation.table].length) {
-                const columnExists = _.find(groupedRelations[relation.table], (statement) => {
-                    /**
-                     * CASE:
-                     * - we should not use the same sub query if the column name is the same (two sub queries)
-                     * - e.g. $and conjunction requires us to use 2 sub queries, because we have to look at each individual tag
-                     */
-                    if (statement.column === relation.column) {
-                        return true;
-                    }
-                });
-
-                if (columnExists) {
-                    const newKey = `${relation.table}_${Math.floor(Math.random() * 100)}`;
-                    if (!groupedRelations[newKey]) {
-                        groupedRelations[newKey] = [];
-                    }
-
-                    groupedRelations[newKey].push(relation);
-                    return;
-                }
-            }
-
-            groupedRelations[relation.table].push(relation);
-        });
+        const groupedRelations = this.groupRelationStatements(relations, mode);
 
         if (debugExtended.enabled) {
             debugExtended(`(buildRelationQuery) grouped: ${JSON.stringify(groupedRelations)}`);
@@ -161,7 +196,7 @@ class MongoToKnex {
         _.each(Object.keys(groupedRelations), (key) => {
             debug(`(buildRelationQuery) build relation for ${key}`);
 
-            const statements = groupedRelations[key];
+            const statements = groupedRelations[key].innerWhereStatements;
 
             // CASE: any statement for the same relation should contain the same config
             const reference = statements[0];
@@ -180,10 +215,19 @@ class MongoToKnex {
 
                     // CASE: WHERE resource.id (IN | NOT IN) (SELECT ...)
                     qb[reference.whereType](`${this.tableName}.id`, comp, function () {
+                        const joinFilterStatements = groupedRelations[key].joinFilterStatements;
                         const innerQB = this
                             .select(`${reference.config.join_table}.${reference.config.join_from}`)
                             .from(`${reference.config.join_table}`)
-                            .innerJoin(`${reference.config.tableName}`, `${reference.config.tableName}.id`, '=', `${reference.config.join_table}.${reference.config.join_to}`);
+                            .innerJoin(`${reference.config.tableName}`, function () {
+                                this.on(`${reference.config.tableName}.id`, '=', `${reference.config.join_table}.${reference.config.join_to}`);
+
+                                // CASE: when applying AND con junction and having multiple groups the filter
+                                //       related to joining table has to be applied within each group
+                                _.each(joinFilterStatements, (joinFilter) => {
+                                    this.andOn(`${joinFilter.join_table}.${joinFilter.column}`, compOps[joinFilter.operator], joinFilter.value);
+                                });
+                            });
 
                         if (debugExtended.enabled) {
                             debug(`(buildRelationQuery) innerQB sql-pre: ${innerQB.toSQL().sql}`);
@@ -241,7 +285,7 @@ class MongoToKnex {
 
             // CASE: if the statement is not part of a group, execute the query instantly
             if (!group) {
-                this.buildRelationQuery(qb, [processedStatement]);
+                this.buildRelationQuery(qb, [processedStatement], mode);
                 return;
             }
 
@@ -306,7 +350,7 @@ class MongoToKnex {
 
             // CASE: now execute all relation statements of this group
             if (_qb.hasOwnProperty('relations')) {
-                this.buildRelationQuery(_qb, _qb.relations);
+                this.buildRelationQuery(_qb, _qb.relations, mode);
                 delete _qb.relations;
             }
         });

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -237,9 +237,10 @@ class MongoToKnex {
         debug(`(buildComparison) mode: ${mode}, op: ${op}, isRelation: ${processedStatement.isRelation}, group: ${group}`);
 
         if (processedStatement.isRelation) {
+            processedStatement.whereType = whereType;
+
             // CASE: if the statement is not part of a group, execute the query instantly
             if (!group) {
-                processedStatement.whereType = whereType;
                 this.buildRelationQuery(qb, [processedStatement]);
                 return;
             }
@@ -249,7 +250,6 @@ class MongoToKnex {
                 qb.relations = [];
             }
 
-            processedStatement.whereType = whereType;
             qb.relations.push(processedStatement);
             return;
         }

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -21,6 +21,7 @@ const compOps = {
 const isOp = key => key.charAt(0) === '$';
 const isLogicOp = key => isOp(key) && _.includes(logicOps, key);
 const isCompOp = key => isOp(key) && _.includes(_.keys(compOps), key);
+const isNegationOp = key => isOp(key) && _.includes(['$ne', '$nin'], key);
 
 class MongoToKnex {
     constructor(options = {}, config = {}) {
@@ -170,7 +171,7 @@ class MongoToKnex {
                     // CASE: only negate whole group when all the operators in the group are negative,
                     // otherwise we cannot combine groups with negated and regular equation operators
                     const negateGroup = _.every(statements.map(s => s.operator), (operator) => {
-                        return ['$ne', '$nin'].includes(operator);
+                        return isNegationOp(operator);
                     });
 
                     const comp = negateGroup
@@ -197,7 +198,7 @@ class MongoToKnex {
                             if (negateGroup) {
                                 statementOp = compOps.$in;
                             } else {
-                                statementOp = (statement.operator === '$ne' || statement.operator === '$nin')
+                                statementOp = isNegationOp(statement.operator)
                                     ? compOps.$nin
                                     : compOps.$in;
                             }

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -97,7 +97,7 @@ class MongoToKnex {
 
         // CASE: fallback, `status=draft` -> `posts.status`=draft
         return {
-            column: this.tableName + '.' + column,
+            column: `${this.tableName}.${column}`,
             value: value,
             isRelation: false
         };

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -166,7 +166,7 @@ class MongoToKnex {
             const reference = statements[0];
 
             if (reference.config.type === 'manyToMany') {
-                if (isCompOp(reference.operator)) {
+                if (_.every(statements.map(s => s.operator), isCompOp)) {
                     const comp = reference.operator === '$ne' || reference.operator === '$nin' ? 'NOT IN' : 'IN';
 
                     // CASE: WHERE resource.id (IN | NOT IN) (SELECT ...)
@@ -184,7 +184,7 @@ class MongoToKnex {
                         return innerQB;
                     });
                 } else {
-                    debug('unknown operator');
+                    debug(`one of ${key} group statements contains unknown operator`);
                 }
             }
         });

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -167,7 +167,15 @@ class MongoToKnex {
 
             if (reference.config.type === 'manyToMany') {
                 if (_.every(statements.map(s => s.operator), isCompOp)) {
-                    const comp = reference.operator === '$ne' || reference.operator === '$nin' ? 'NOT IN' : 'IN';
+                    // CASE: only negate whole group when all the operators in the group are negative,
+                    // otherwise we cannot combine groups with negated and regular equation operators
+                    const negateGroup = _.every(statements.map(s => s.operator), (operator) => {
+                        return ['$ne', '$nin'].includes(operator);
+                    });
+
+                    const comp = negateGroup
+                        ? compOps.$nin
+                        : compOps.$in;
 
                     // CASE: WHERE resource.id (IN | NOT IN) (SELECT ...)
                     qb[reference.whereType](`${this.tableName}.id`, comp, function () {
@@ -176,10 +184,31 @@ class MongoToKnex {
                             .from(`${reference.config.join_table}`)
                             .innerJoin(`${reference.config.tableName}`, `${reference.config.tableName}.id`, '=', `${reference.config.join_table}.${reference.config.join_to}`);
 
-                        _.each(statements, (value, key) => {
+                        if (debugExtended.enabled) {
+                            debug(`(buildRelationQuery) innerQB sql-pre: ${innerQB.toSQL().sql}`);
+                        }
+
+                        _.each(statements, (statement, key) => {
                             debug(`(buildRelationQuery) build relation where statements for ${key}`);
-                            innerQB[value.whereType](`${value.join_table || value.table}.${value.column}`, 'IN', !_.isArray(value.value) ? [value.value] : value.value);
+
+                            const statementColumn = `${statement.join_table || statement.table}.${statement.column}`;
+                            let statementOp;
+
+                            if (negateGroup) {
+                                statementOp = compOps.$in;
+                            } else {
+                                statementOp = (statement.operator === '$ne' || statement.operator === '$nin')
+                                    ? compOps.$nin
+                                    : compOps.$in;
+                            }
+                            const statementValue = !_.isArray(statement.value) ? [statement.value] : statement.value;
+
+                            innerQB[statement.whereType](statementColumn, statementOp, statementValue);
                         });
+
+                        if (debugExtended.enabled) {
+                            debug(`(buildRelationQuery) innerQB sql-post: ${innerQB.toSQL().sql}`);
+                        }
 
                         return innerQB;
                     });

--- a/test/integration/relations.test.js
+++ b/test/integration/relations.test.js
@@ -351,7 +351,6 @@ describe('Relations', function () {
                 };
 
                 const query = makeQuery(mongoJSON);
-                console.log(query.toQuery());
 
                 return query
                     .select()
@@ -597,7 +596,7 @@ describe('Relations', function () {
 
         describe('Multiple where clauses for relations', function () {
             it('tags.slug equals "cgi" and posts_tags.sort_order is 0 and featured is true', function () {
-                // where primary tag is "animal"
+                // where primary tag is "cgi"
                 const mongoJSON = {
                     $and: [
                         {

--- a/test/integration/relations.test.js
+++ b/test/integration/relations.test.js
@@ -152,25 +152,6 @@ describe('Relations', function () {
                         result.should.be.an.Array().with.lengthOf(2);
                     });
             });
-
-            it('tags.slug NOT equal "classic" and tags.visibility is equal "public"', function () {
-                const mongoJSON = {
-                    'tags.visibility': 'public',
-                    'tags.slug': {
-                        $ne: 'classic'
-                    }
-                };
-
-                const query = makeQuery(mongoJSON);
-
-                return query
-                    .select()
-                    .then((result) => {
-                        result.should.be.an.Array().with.lengthOf(2);
-                        result[0].title.should.equal('The Bare Necessities');
-                        result[1].title.should.equal('When She Loved Me');
-                    });
-            });
         });
 
         describe('AND $and', function () {
@@ -217,7 +198,7 @@ describe('Relations', function () {
                     });
             });
 
-            it('tags.slug is animal and tags.slug not in []', function () {
+            it('tags.slug is animal and tags.slug NOT in [classic]', function () {
                 const mongoJSON = {
                     $and: [
                         {
@@ -237,32 +218,7 @@ describe('Relations', function () {
                     .select()
                     .then((result) => {
                         result.should.be.an.Array().with.lengthOf(1);
-                    });
-            });
-
-            it('tags.slug is not animal and tags.slug is not cgi', function () {
-                // equivalent to $nin: ['animal', 'cgi']
-                const mongoJSON = {
-                    $and: [
-                        {
-                            'tags.slug': {
-                                $ne: 'animal'
-                            }
-                        },
-                        {
-                            'tags.slug': {
-                                $ne: 'cgi'
-                            }
-                        }
-                    ]
-                };
-
-                const query = makeQuery(mongoJSON);
-
-                return query
-                    .select()
-                    .then((result) => {
-                        result.should.be.an.Array().with.lengthOf(4);
+                        result[0].title.should.equal('The Bare Necessities');
                     });
             });
 
@@ -313,6 +269,7 @@ describe('Relations', function () {
                     .select()
                     .then((result) => {
                         result.should.be.an.Array().with.lengthOf(1);
+                        result[0].title.should.equal('The Bare Necessities');
                     });
             });
 
@@ -337,6 +294,100 @@ describe('Relations', function () {
                     .select()
                     .then((result) => {
                         result.should.be.an.Array().with.lengthOf(1);
+                    });
+            });
+
+            it('tags.slug is NOT animal and tags.slug is NOT cgi', function () {
+                // equivalent to $nin: ['animal', 'cgi']
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tags.slug': {
+                                $ne: 'animal'
+                            }
+                        },
+                        {
+                            'tags.slug': {
+                                $ne: 'cgi'
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(4);
+                    });
+            });
+
+            it('tags.slug NOT equal "classic" and tags.visibility is equal "public"', function () {
+                const mongoJSON = {
+                    'tags.visibility': 'public',
+                    'tags.slug': {
+                        $ne: 'classic'
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result[0].title.should.equal('The Bare Necessities');
+                        result[1].title.should.equal('When She Loved Me');
+                    });
+            });
+
+            it('tags.slug NOT equal "classic" and tags.visibility is equal "public"', function () {
+                const mongoJSON = {
+                    'tags.visibility': 'public',
+                    'tags.slug': {
+                        $nin: ['classic']
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+                console.log(query.toQuery());
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result[0].title.should.equal('The Bare Necessities');
+                        result[1].title.should.equal('When She Loved Me');
+                    });
+            });
+
+            it('(tags.slug NOT  IN "classic" and tags.visibility is equal "public")', function () {
+                // this case can be generated with:
+                // 'tags.slug:-classic+tags.visibility:public'
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tags.visibility': 'public'
+                        },
+                        {
+                            'tags.slug': {
+                                $nin: ['classic']
+                            }
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+                // NOTE: this query is generating a group, this should be avoided
+                // as we can't group negated properties with other, unless those
+                // are going through connecting table
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result[0].title.should.equal('The Bare Necessities');
+                        result[1].title.should.equal('When She Loved Me');
                     });
             });
         });
@@ -606,8 +657,7 @@ describe('Relations', function () {
                     });
             });
 
-            it('tags.slug NOT equal "animal" and posts_tags.sort_order is 0 and featured is false', function () {
-                // where primary tag is "animal"
+            it('tags.slug NOT equal "classic" and posts_tags.sort_order is 0 and featured is true', function () {
                 const mongoJSON = {
                     $and: [
                         {
@@ -618,7 +668,7 @@ describe('Relations', function () {
                                     }
                                 },
                                 {
-                                    'posts_tags.sort_order': 1
+                                    'posts_tags.sort_order': 0
                                 }
                             ]
                         },
@@ -629,15 +679,14 @@ describe('Relations', function () {
                 };
 
                 const query = makeQuery(mongoJSON);
-                // NOTE: the negation is being put on the outer IN incorrectly
-                // console.log(query.toQuery());
 
                 return query
                     .select()
                     .then((result) => {
+                        // TODO: should this include tags with no tags? the filter is about primary tag != 'classic' so they should count?
                         result.should.be.an.Array().with.lengthOf(3);
-                        result[0].title.should.equal('Circle of Life');
-                        result[1].title.should.equal('He\'s a Tramp');
+                        result[0].title.should.equal('When She Loved Me');
+                        result[1].title.should.equal('no tags, yeah');
                         result[2].title.should.equal('has internal tag');
                     });
             });

--- a/test/integration/relations.test.js
+++ b/test/integration/relations.test.js
@@ -152,6 +152,25 @@ describe('Relations', function () {
                         result.should.be.an.Array().with.lengthOf(2);
                     });
             });
+
+            it('tags.slug NOT equal "classic" and tags.visibility is equal "public"', function () {
+                const mongoJSON = {
+                    'tags.visibility': 'public',
+                    'tags.slug': {
+                        $ne: 'classic'
+                    }
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(2);
+                        result[0].title.should.equal('The Bare Necessities');
+                        result[1].title.should.equal('When She Loved Me');
+                    });
+            });
         });
 
         describe('AND $and', function () {

--- a/test/integration/relations.test.js
+++ b/test/integration/relations.test.js
@@ -247,6 +247,28 @@ describe('Relations', function () {
                     });
             });
 
+            it('tags.slug is animal and sort_order is 0 and tags.visibility=public', function () {
+                const mongoJSON = {
+                    $and: [
+                        {
+                            'tags.slug': 'animal'
+                        },
+                        {
+                            'posts_tags.sort_order': 0
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                        result[0].title.should.equal('The Bare Necessities');
+                    });
+            });
+
             it('(tags.slug is animal and sort_order is 0) and tags.visibility=public', function () {
                 const mongoJSON = {
                     $and: [
@@ -562,6 +584,42 @@ describe('Relations', function () {
                     .then((result) => {
                         result.should.be.an.Array().with.lengthOf(1);
                         result[0].title.should.equal('The Bare Necessities');
+                    });
+            });
+
+            it('tags.slug NOT equal "animal" and posts_tags.sort_order is 0 and featured is false', function () {
+                // where primary tag is "animal"
+                const mongoJSON = {
+                    $and: [
+                        {
+                            $and: [
+                                {
+                                    'tags.slug': {
+                                        $ne: 'classic'
+                                    }
+                                },
+                                {
+                                    'posts_tags.sort_order': 1
+                                }
+                            ]
+                        },
+                        {
+                            featured: true
+                        }
+                    ]
+                };
+
+                const query = makeQuery(mongoJSON);
+                // NOTE: the negation is being put on the outer IN incorrectly
+                // console.log(query.toQuery());
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(3);
+                        result[0].title.should.equal('Circle of Life');
+                        result[1].title.should.equal('He\'s a Tramp');
+                        result[2].title.should.equal('has internal tag');
                     });
             });
 


### PR DESCRIPTION
refs https://github.com/NexesJS/mongo-knex/issues/5
refs https://github.com/NexesJS/mongo-knex/issues/7

This was an attempt to expand existing conjunctions but ended up as a cleanup and extension of existing test cases. The main operation that was missing and has been added is negation and conjunctions support that used joining table in it's filter, e.g:
```
{
        {
            $and: [
                {
                    'tags.slug': {
                        $ne: 'classic'
                    }
                },
                {
                    'posts_tags.sort_order': 0
                }
            ]
        },
        {
            featured: true
        }
    ]
}
```

The rest of M:M cases now seems to be covered.