### PR TITLE
Improved support for complex relations 

### DIFF
--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -231,12 +231,12 @@ class MongoToKnex {
                         const joinFilterStatements = groupedRelations[key].joinFilterStatements;
 
                         let innerJoinValue = reference.config.tableName;
-                        let innerJoinOn = `${reference.config.tableName}.id`;
+                        let innerJoinOn = `${reference.config.tableName}.${reference.config.joinToForeign || 'id'}`;
 
                         // CASE: you can define a name for the join table
                         if (reference.config.tableNameAs) {
                             innerJoinValue = `${reference.config.tableName} as ${reference.config.tableNameAs}`;
-                            innerJoinOn = `${reference.config.tableNameAs}.id`;
+                            innerJoinOn = `${reference.config.tableNameAs}.${reference.config.joinToForeign || 'id'}`;
                         }
 
                         const innerQB = this

--- a/lib/convertor.js
+++ b/lib/convertor.js
@@ -239,9 +239,15 @@ class MongoToKnex {
                             innerJoinOn = `${reference.config.tableNameAs}.${reference.config.joinToForeign || 'id'}`;
                         }
 
-                        const innerQB = this
+                        let query = this
                             .select(`${reference.config.joinTable}.${reference.config.joinFrom}`)
-                            .from(`${reference.config.joinTable}`)
+                            .from(`${reference.config.joinTable}`);
+
+                        if (reference.config.virtualTable) {
+                            query = query.with(reference.config.tableName, reference.config.virtualTableDefinition);
+                        }
+
+                        const innerQB = query
                             .innerJoin(innerJoinValue, function () {
                                 this.on(innerJoinOn, '=', `${reference.config.joinTable}.${reference.config.joinTo}`);
 
@@ -317,9 +323,15 @@ class MongoToKnex {
                             innerJoinOn = `${reference.config.tableNameAs}.${reference.config.joinFrom}`;
                         }
 
-                        const innerQB = this
+                        let query = this
                             .select(`${tableName}.id`)
-                            .from(`${tableName}`)
+                            .from(`${tableName}`);
+
+                        if (reference.config.virtualTable) {
+                            query = query.with(reference.config.tableName, reference.config.virtualTableDefinition);
+                        }
+
+                        const innerQB = query
                             .leftJoin(innerJoinValue, function () {
                                 this.on(innerJoinOn, '=', `${tableName}.id`);
 

--- a/test/integration/relations.test.js
+++ b/test/integration/relations.test.js
@@ -29,6 +29,14 @@ const makeQuery = (mongoJSON) => {
                 tableName: 'posts_meta',
                 type: 'oneToOne',
                 joinFrom: 'post_id'
+            },
+            comments: {
+                tableName: 'comments',
+                type: 'manyToMany',
+                joinTable: 'posts_comments',
+                joinFrom: 'post_id',
+                joinTo: 'comment_id',
+                joinToForeign: 'comment_provider_id'
             }
         }
     });
@@ -47,6 +55,23 @@ describe('Relations', function () {
 
     describe('Many-to-Many', function () {
         before(utils.db.init('many-to-many'));
+
+        describe('joinToForeign', function () {
+            it('Allows you to join an a customer foreign key in the resulting row', function () {
+                const mongoJSON = {
+                    'comments.content': 'Hello, world'
+                };
+
+                const query = makeQuery(mongoJSON);
+
+                return query
+                    .select()
+                    .then((result) => {
+                        result.should.be.an.Array().with.lengthOf(1);
+                        result.should.matchIds([1]);
+                    });
+            });
+        });
 
         describe('EQUALS $eq', function () {
             it('tags.slug equals "animal"', function () {

--- a/test/integration/suite1/fixtures/base.json
+++ b/test/integration/suite1/fixtures/base.json
@@ -154,5 +154,61 @@
             "meta_description": null,
             "like_count": 42
         }
+    ],
+    "posts_view_events": [
+        {
+            "id": 1,
+            "post_id": 1,
+            "count": 2,
+            "date": "2021-01-01"
+        },
+        {
+            "id": 2,
+            "post_id": 2,
+            "count": 4,
+            "date": "2021-01-01"
+        },
+        {
+            "id": 3,
+            "post_id": 3,
+            "count": 0,
+            "date": "2021-01-01"
+        },
+        {
+            "id": 4,
+            "post_id": 1,
+            "count": 6,
+            "date": "2021-01-02"
+        },
+        {
+            "id": 5,
+            "post_id": 2,
+            "count": 3,
+            "date": "2021-01-02"
+        },
+        {
+            "id": 6,
+            "post_id": 3,
+            "count": 0,
+            "date": "2021-01-02"
+        },
+        {
+            "id": 7,
+            "post_id": 1,
+            "count": 5,
+            "date": "2021-01-03"
+        },
+        {
+            "id": 8,
+            "post_id": 2,
+            "count": 7,
+            "date": "2021-01-03"
+        },
+        {
+            "id": 9,
+            "post_id": 3,
+            "count": 10,
+            "date": "2021-01-03"
+        }
     ]
 }

--- a/test/integration/suite1/fixtures/base.json
+++ b/test/integration/suite1/fixtures/base.json
@@ -120,6 +120,18 @@
             "created_at": "2015-06-22"
         }
     ],
+    "comments": [
+        {
+            "id": 1,
+            "comment_provider_id": "external_1",
+            "content": "Hello, world"
+        },
+        {
+            "id": 2,
+            "comment_provider_id": "external_2",
+            "content": "Learn forex trading today and make millions, only a 1000 USD up front payment! bit.ly/scam"
+        }
+    ],
     "posts_meta": [
         {
             "id": 1,

--- a/test/integration/suite1/fixtures/many-to-many.json
+++ b/test/integration/suite1/fixtures/many-to-many.json
@@ -22,5 +22,10 @@
         {"post_id": 7, "author_id": 1, "sort_order": 0},
         {"post_id": 8, "author_id": 2, "sort_order": 0},
         {"post_id": 8, "author_id": 3, "sort_order": 1}
+    ],
+
+    "posts_comments": [
+        {"post_id": 1, "comment_id": "external_1"},
+        {"post_id": 2, "comment_id": "external_2"}
     ]
 }

--- a/test/integration/suite1/schema.js
+++ b/test/integration/suite1/schema.js
@@ -2,6 +2,7 @@ const Promise = require('bluebird');
 const TABLES = [
     'posts_comments',
     'comments',
+    'posts_view_events',
     'posts_tags',
     'posts_authors',
     'posts_meta',
@@ -53,6 +54,12 @@ module.exports.up = function (knex) {
             table.integer('post_id').unsigned().references('posts.id');
             table.integer('author_id').unsigned().references('users.id');
             table.integer('sort_order').defaultTo(0);
+        }))
+        .then(() => knex.schema.createTable('posts_view_events', (table) => {
+            table.increments('id').primary();
+            table.integer('post_id').unsigned().references('posts.id');
+            table.integer('count');
+            table.dateTime('date');
         }))
         .then(() => knex.schema.createTable('comments', (table) => {
             table.increments('id').primary();

--- a/test/integration/suite1/schema.js
+++ b/test/integration/suite1/schema.js
@@ -1,5 +1,7 @@
 const Promise = require('bluebird');
 const TABLES = [
+    'posts_comments',
+    'comments',
     'posts_tags',
     'posts_authors',
     'posts_meta',
@@ -51,6 +53,16 @@ module.exports.up = function (knex) {
             table.integer('post_id').unsigned().references('posts.id');
             table.integer('author_id').unsigned().references('users.id');
             table.integer('sort_order').defaultTo(0);
+        }))
+        .then(() => knex.schema.createTable('comments', (table) => {
+            table.increments('id').primary();
+            table.string('comment_provider_id');
+            table.string('content');
+        }))
+        .then(() => knex.schema.createTable('posts_comments', (table) => {
+            table.increments('id').primary();
+            table.integer('post_id').unsigned().references('posts.id');
+            table.string('comment_id').references('comments.comment_provider_id');
         }));
 };
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/944

This allows consumers of the library to setup more complex relations which can be filtered on, which is required for the work in the linked issue.

We now allow to pass a customer foreign key in the manyToMany relationship, rather than forcing the resulting record to be linked by it's `id` column. This is useful when resources are linked using their external id, rather than internal id, e.g. Stripe entities

We also add a new feature of adding a relation to a "virtual table" - these are defined as a raw SQL string, and allow us to use aggregates in our relations, as well as joining over multiple tables.